### PR TITLE
Bug/spec layout bg 22

### DIFF
--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -2,7 +2,7 @@
 layout: default
 breadcrumbs:
   - label: Get Started
-    link: 'get-started'
+    link: '{{ site.root_url }}/get-started'
   - label: APIs & Documentation
     link: 'api'
 ---

--- a/_sass/iiifc-theme/base.scss
+++ b/_sass/iiifc-theme/base.scss
@@ -18,7 +18,7 @@ $caption-grey: #5f5f5f;
 
 /* bulma overrides */
 
-$background: $lighter-grey;
+$background: $white;
 $primary: $blue;
 $primary-dark: $navy;
 $text: $black;
@@ -68,6 +68,11 @@ $content-max-width: 780px;
 
 html {
   scroll-behavior: smooth;
+  background-color: $white;
+}
+
+body {
+  background-color: $white;
 }
 
 @mixin heading {

--- a/_sass/iiifc-theme/base.scss
+++ b/_sass/iiifc-theme/base.scss
@@ -5,6 +5,7 @@ $blue: #0073b0;
 $white: #ffffff;
 $dark-blue: #003654;
 $light-blue: rgba(141, 195, 223, 0.08);
+$light-bluer: rgba(141, 195, 223, 0.25);
 $navy: #001927;
 $navy-scrim: rgba(0, 25, 39, 0.8);
 $red: #a40832;
@@ -291,9 +292,10 @@ pre.highlight {
     td {
       border: solid 1px $black;
       border-style: inset;
+      background-color: $white;
     }
     thead {
-      background-color: $light-blue;
+      background-color: $light-bluer;
       color: $dark-blue;
       font-size: 1.125rem;
       font-family: $family-serif;


### PR DESCRIPTION
re: #22 
- [x] increases opacity on light blue table header 
- [x] ensures table body is white regardless of background 
- [x] also fixes breadcrumb `root_url` on spec pages