### PR TITLE
*max* width specs, tables, imgs, code wrap

### DIFF
--- a/_includes/content/full-width-image.html
+++ b/_includes/content/full-width-image.html
@@ -1,4 +1,4 @@
-<div class="container is-widescreen has-text-left">
+<div class="container mgt-medium mgb-medium">
   <img alt="{{ include.alt_text }}" src="{{ include.image | absolute_url }}" />
   <span class="caption">{{ include.caption }}</span>
 </div>

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -2,7 +2,7 @@
 layout: default
 breadcrumbs:
   - label: Get Started
-    link: 'get-started'
+    link: '{{ site.root_url }}/get-started'
   - label: APIs & Documentation
     link: 'api'
 ---

--- a/_layouts/spec.html
+++ b/_layouts/spec.html
@@ -12,14 +12,14 @@ breadcrumbs:
   {% assign content = content | replace: upper, lower %}
 {% endfor %}
 
-<div class="container-block is-max-widescreen">
-  <div class="columns container">
-    <aside class="column is-one-quarter" markdown="1">
-      <div class="box toc-sidebar sticky">
+<div class="container-block no-padding is-max-desktop">
+  <div class="columns is-max-desktop">
+    <aside class="column is-one-third api-sidebar-container" markdown="1">
+      <div class="toc-sidebar sticky">
         {% include api/toc.html html=content h_max=3 id='toc-menu' class='menu' submenu_class='menu-list toc-submenu-%level%' %}
       </div>
     </aside>
-    <div class="column content is-three-quarters api-content" markdown="1">
+    <div class="column is-two-thirds content api-content" markdown="1">
       {% include api/anchor_headings.html html=content anchorBody="#" %}
     </div>
   </div>

--- a/_sass/iiifc-theme/base.scss
+++ b/_sass/iiifc-theme/base.scss
@@ -5,6 +5,7 @@ $blue: #0073b0;
 $white: #ffffff;
 $dark-blue: #003654;
 $light-blue: rgba(141, 195, 223, 0.08);
+$light-bluer: rgba(141, 195, 223, 0.25);
 $navy: #001927;
 $navy-scrim: rgba(0, 25, 39, 0.8);
 $red: #a40832;
@@ -305,9 +306,10 @@ pre.highlight {
     td {
       border: solid 1px $black;
       border-style: inset;
+      background-color: $white;
     }
     thead {
-      background-color: $light-blue;
+      background-color: $light-bluer;
       color: $dark-blue;
       font-size: 1rem;
       font-family: $family-serif;

--- a/_sass/iiifc-theme/base.scss
+++ b/_sass/iiifc-theme/base.scss
@@ -18,7 +18,7 @@ $caption-grey: #5f5f5f;
 
 /* bulma overrides */
 
-$background: $lighter-grey;
+$background: $white;
 $primary: $blue;
 $primary-dark: $navy;
 $text: $black;
@@ -68,6 +68,11 @@ $content-max-width: 780px;
 
 html {
   scroll-behavior: smooth;
+  background-color: $white;
+}
+
+body {
+  background-color: $white;
 }
 
 @mixin heading {

--- a/_sass/iiifc-theme/base.scss
+++ b/_sass/iiifc-theme/base.scss
@@ -216,7 +216,7 @@ h3 {
   font-weight: bold;
 
   li {
-    font-size: $size-7;
+    font-size: 1rem;
   }
   a:hover {
     color: $dark-blue;
@@ -296,6 +296,7 @@ pre.highlight {
   padding: 3.5rem;
   max-width: 100% !important;
   margin: unset !important;
+  line-height: 2;
   p,
   li,
   .code-header,
@@ -329,7 +330,7 @@ pre.highlight {
     }
   }
   .rfc {
-    color: #d55;
+    color: $red;
     font-variant: small-caps;
     font-style: normal;
     font-size: 1.2em;
@@ -555,4 +556,16 @@ hr {
   .menu {
     padding: 3rem 3.5rem 2.5rem 0;
   }
+}
+
+code.language-plaintext {
+  padding: 0.2em 0.15em;
+  font-weight: 400;
+  background-color: $grey;
+  border: 1px solid #dddddd;
+  border-radius: 4px;
+  font-size: 0.8em;
+  line-height: 2;
+  color: $black;
+  font-family: "Courier Prime", monospace;
 }

--- a/_sass/iiifc-theme/base.scss
+++ b/_sass/iiifc-theme/base.scss
@@ -113,6 +113,7 @@ h3 {
 }
 
 .hero {
+  margin-bottom: .75rem;
   .title {
     font-family: $family-serif;
     color: $white !important;
@@ -231,6 +232,12 @@ pre.highlight {
   border-bottom-right-radius: 1em;
   margin: 0 0 1em 0;
 
+  white-space: pre-wrap;       /* Since CSS 2.1 */
+  white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+  white-space: -pre-wrap;      /* Opera 4-6 */
+  white-space: -o-pre-wrap;    /* Opera 7 */
+  word-wrap: break-word;       /* Internet Explorer 5.5+ */
+
   code {
     font-family: "Courier Prime", monospace;
   }
@@ -280,14 +287,21 @@ pre.highlight {
 }
 
 .api-content {
+  padding: 3.5rem;
+  max-width: 100% !important;
+  margin: unset !important;
   p,
-  li {
-    max-width: $container-max-width;
+  li,
+  .code-header,
+  .highlight {
+    max-width: $content-max-width;
   }
   table {
-    overflow-y: scroll;
-    display: block;
     border-collapse: collapse;
+    display: block;
+    max-width: -moz-fit-content;
+    max-width: fit-content;
+    overflow-x: auto;
     td {
       border: solid 1px $black;
       border-style: inset;
@@ -295,7 +309,7 @@ pre.highlight {
     thead {
       background-color: $light-blue;
       color: $dark-blue;
-      font-size: 1.125rem;
+      font-size: 1rem;
       font-family: $family-serif;
       th {
         border: solid 1px $black;
@@ -520,4 +534,18 @@ hr {
 .float-left {
   float: left;
   margin-left: 0 !important;
+}
+
+.no-padding {
+  padding: 0 !important;
+}
+
+.api-sidebar-container {
+  background-color: $light-blue;
+  padding-left: 3.5rem;
+  padding-right: 0;
+  margin-bottom: 0.75rem;
+  .menu {
+    padding: 3rem 3.5rem 2.5rem 0;
+  }
 }


### PR DESCRIPTION
attempt to eliminate all avoidable side-scrolling. includes:
- [x] max with spec images and tables #19 
- [x] text wrapping in code blocks (i was totally wrong! this was a pure CSS fix and doesn't break code copy) #21
- [x] completely redesigned spec page sidebar to mimic w3c and appropriate margin space 