### PR TITLE
init global rake tasks from theme

### DIFF
--- a/iiifc-theme.gemspec
+++ b/iiifc-theme.gemspec
@@ -14,15 +14,15 @@ Gem::Specification.new do |spec|
   spec.metadata["plugin_type"] = "theme"
 
   spec.files = `git ls-files -z`.split("\x0").select do |f|
-    f.match(%r!^(assets|_(includes|layouts|sass|data)/|(LICENSE|README)((\.(txt|md|markdown)|$)))!i)
+    f.match(%r!^(assets|lib|_(includes|layouts|sass|data)/|(LICENSE|README)((\.(txt|md|markdown)|$)))!i)
   end
 
-  spec.add_runtime_dependency "jekyll", ">= 4.0", "< 5.0"
+  spec.add_runtime_dependency "html-proofer"
+  spec.add_runtime_dependency "jekyll", ">= 4.0", "< 4.2"
   spec.add_runtime_dependency "jekyll-data"
   spec.add_runtime_dependency "jekyll-gzip"
   spec.add_runtime_dependency "jekyll-redirect-from"
   spec.add_runtime_dependency "jekyll-sitemap"
   spec.add_runtime_dependency "jekyll-liquify"
-
-  spec.add_development_dependency "bundler"
+  spec.add_runtime_dependency "rake"
 end

--- a/lib/iiifc.rb
+++ b/lib/iiifc.rb
@@ -1,0 +1,9 @@
+require 'fileutils'
+require 'html-proofer'
+require 'yaml'
+
+SITE_DIR = './_site'
+CONFIG   = YAML.load_file './_config.yml'
+SITE_ID  = ENV['SITE_ID'] || CONFIG.fetch('site_id', 'root')
+
+module Iiifc ; end

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -1,0 +1,33 @@
+require 'iiifc'
+
+namespace :build do
+  def build(dest=nil, baseurl=nil)
+    sh "bundle exec jekyll clean"
+    cmd = "bundle exec jekyll build"
+    cmd += " -d '#{dest}'" unless dest.nil?
+    cmd += " --baseurl '#{baseurl}'" unless baseurl.nil?
+    sh cmd
+  end
+
+  desc 'Clean and build with branch preview URL overrides'
+  task :preview do
+    branch = `git rev-parse --abbrev-ref HEAD`.strip
+    baseurl = "/#{SITE_ID}/#{branch}"
+    dest    = SITE_DIR + baseurl
+
+    build dest=dest, baseurl=baseurl
+  end
+
+  desc 'Clean and build with CI test overrides'
+  task :ci do
+    baseurl = '/test/extra-test'
+    dest    = SITE_DIR + baseurl
+
+    build dest=dest, baseurl=baseurl
+  end
+
+  desc 'Clean and build with no overrrides'
+  task :default do
+    build
+  end
+end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,0 +1,59 @@
+require 'iiifc'
+
+namespace :test do
+  desc 'Check html'
+  task :html do
+    opts = {
+      check_html: true,
+      assume_extension: true,
+      validation: {
+        report_mismatched_tags: true,
+        report_invalid_tags: true
+      },
+      checks_to_ignore: ['LinkCheck']
+    }
+    HTMLProofer.check_directory(SITE_DIR, opts).run
+  end
+
+  namespace :links do
+    desc 'Check for internal link errors'
+    task :internal do
+      puts 'Checking for internal link errors'
+      opts = {
+        checks_to_ignore: ['ImageCheck', 'HtmlCheck', 'ScriptCheck'],
+        disable_external: true,
+        internal_domains: ['localhost:4000']
+      }
+      HTMLProofer.check_directory(SITE_DIR, opts).run
+    end
+
+    desc 'Check for *iiif.io* link errors'
+    task :iiif do
+      puts 'Checking for link errors in *iiif.io* sites'
+      opts = {
+        checks_to_ignore: ['ImageCheck', 'HtmlCheck', 'ScriptCheck'],
+        url_ignore: [/^((?!iiif\.io).)*$/, 'github'] # temporarily ignore iiif.io github repo errors
+      }
+      HTMLProofer.check_directory(SITE_DIR, opts).run
+    end
+
+    desc 'Check for external link rot'
+    task :external do
+      puts 'Checking for external link errors'
+      opts = {
+        external_only: true,
+        http_status_ignore: [429],
+        enforce_https: true,
+        only_4xx: true,
+        checks_to_ignore: ['ImageCheck', 'HtmlCheck', 'ScriptCheck'],
+        url_ignore: [/.*iiif\.io.*/]
+      }
+      HTMLProofer.check_directory(SITE_DIR, opts).run
+    end
+
+    desc 'Run rspec tests (if they exist)'
+    task :spec do
+
+    end
+  end
+end


### PR DESCRIPTION
Resolves #20: (see checklist on: https://github.com/IIIF/api/pull/2026#issuecomment-883465690)
- [x] adding rake tasks for building and testing preview sites to the theme
- [x] sites will inherit tasks from theme and define their own as needed (e.g., `api:spec`)

(Last steps: tell `api` and `website` repos to use `main` theme branch once this is merged)